### PR TITLE
fix compiler warning: conversion from NULL

### DIFF
--- a/src/gnome-cmd-file-list.cc
+++ b/src/gnome-cmd-file-list.cc
@@ -184,8 +184,8 @@ struct GnomeCmdFileList::Private
 
 GnomeCmdFileList::Private::Private(GnomeCmdFileList *fl)
 {
-    memset(column_pixmaps, NULL, sizeof(column_pixmaps));
-    memset(column_labels, NULL, sizeof(column_labels));
+    memset(column_pixmaps, 0, sizeof(column_pixmaps));
+    memset(column_labels, 0, sizeof(column_labels));
 
     base_dir = NULL;
 

--- a/src/gnome-cmd-file.cc
+++ b/src/gnome-cmd-file.cc
@@ -609,7 +609,7 @@ const gchar *GnomeCmdFile::get_type_desc()
 
 gboolean GnomeCmdFile::get_type_pixmap_and_mask(GdkPixmap **pixmap, GdkBitmap **mask)
 {
-    g_return_val_if_fail (info != NULL, NULL);
+    g_return_val_if_fail (info != NULL, FALSE);
 
     return IMAGE_get_pixmap_and_mask (info->type, info->mime_type, info->symlink_name != NULL, pixmap, mask);
 }


### PR DESCRIPTION
- gnome-cmd-file-list.cc:185:56: warning: passing NULL to non-pointer
   argument 2 of ‘void* memset(void*, int, size_t)’ [-Wconversion-null]
- gnome-cmd-file-list.cc:186:54: warning: passing NULL to non-pointer
   argument 2 of ‘void* memset(void*, int, size_t)’ [-Wconversion-null]
- gnome-cmd-file.cc:612:5: warning: converting to non-pointer type
   ‘gboolean {aka int}’ from NULL [-Wconversion-null]

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>