### PR TITLE
Simple plug-in system for file context menu

### DIFF
--- a/gcmd-scripts/duplicate.sh
+++ b/gcmd-scripts/duplicate.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#name: Duplicate
+
+# Written by puux <puuxmine@gmail.com> 2016
+# Part of gnome-commander script plug-in system
+
+for n in $@
+do
+  cp $n "1_$n"
+done
+

--- a/gcmd-scripts/filelist.sh
+++ b/gcmd-scripts/filelist.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#name: File list
+#term: true
+
+# Written by puux <puuxmine@gmail.com> 2016
+# Part of gnome-commander script plug-in system
+
+echo "Enter file name:"
+read list
+
+for n in $@
+do
+  echo "$n" >> $list.txt
+done
+

--- a/gcmd-scripts/tar.sh
+++ b/gcmd-scripts/tar.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#name: *.tar.gz
+
+# Written by puux <puuxmine@gmail.com> 2016
+# Part of gnome-commander script plug-in system
+
+tar -cf archive.tar.gz $@ -z
+

--- a/gcmd-scripts/trash.sh
+++ b/gcmd-scripts/trash.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#name: Move to trash
+
+# Written by puux <puuxmine@gmail.com> 2016
+# Part of gnome-commander script plug-in system
+
+for n in $@
+do
+  mv $n ~/.local/share/Trash/
+done
+


### PR DESCRIPTION
I would like to add a very simple scripting support in the file context menu.

![preview]
(http://i.mcgl.ru/7DVkUhNIq7)

**How it works?**

1) Create ~/.gnome-commander/scripts/ directory
2) Create shell script in this place, like as:

> #!/bin/sh
> #name: Make tar gz
> 
> tar -cf archive.tar.gz $@ -z

3) Open file context menu and click "Make tar gz"

**Script properties**
The following properties can be inserted in the header of the script:

_name_ - the name of the menu item
_term_ - run the script in a terminal window

Property format: #[prop name]: [value]

**Additional features**
If you press the Shift key, the script called for each selected file. Otherwise, the script transmitted the names of all selected files as arguments.

**Script examples**
Duplicate selected files:

> #!/bin/sh
> #name: Duplicate
> 
> for n in $@
> do
>   cp $n "1_$n"
> done

Create file list:

> #!/bin/sh
> #name: File list
> #term: true
> 
> echo "Enter file name:"
> read list
> 
> for n in $@
> do
>   echo "$n" >> $list.txt
> done

Move files to trash

> #!/bin/sh
> #name: Move to trash
> 
> for n in $@
> do
>   mv $n ~/.local/share/Trash/
> done

Please tell me which folder to put the script examples in the repository, so they can be used by other people?

**TODO**
- custom icons in popup menu
- support folders as submenu