### PR TITLE
Sync bookmarks between all instances of gnome-commander

### DIFF
--- a/src/dialogs/gnome-cmd-manage-bookmarks-dialog.cc
+++ b/src/dialogs/gnome-cmd-manage-bookmarks-dialog.cc
@@ -65,6 +65,7 @@ enum
 
 const int RESPONSE_JUMP_TO = 123;
 
+GtkWidget *view = NULL;
 
 void gnome_cmd_bookmark_dialog_new (const gchar *title, GtkWindow *parent)
 {
@@ -79,7 +80,7 @@ void gnome_cmd_bookmark_dialog_new (const gchar *title, GtkWindow *parent)
     GtkWidget *content_area = gtk_dialog_get_content_area(GTK_DIALOG (dialog));
 #endif
 
-    GtkWidget *vbox, *hbox, *scrolled_window, *view, *button;
+    GtkWidget *vbox, *hbox, *scrolled_window, *button;
 
     gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_CENTER);
     gtk_dialog_set_has_separator (GTK_DIALOG (dialog), FALSE);
@@ -158,17 +159,13 @@ void gnome_cmd_bookmark_dialog_new (const gchar *title, GtkWindow *parent)
     gtk_dialog_run (GTK_DIALOG (dialog));
 
     gtk_widget_destroy (dialog);
+    view = NULL;
 }
 
 
-static GtkTreeModel *create_and_fill_model (GtkTreePath *&current_group)
+static void fill_tree (GtkTreeStore *store, GtkTreePath *&current_group)
 {
-    GtkTreeStore *store = gtk_tree_store_new (NUM_COLUMNS,
-                                              G_TYPE_STRING,
-                                              G_TYPE_STRING,
-                                              G_TYPE_STRING,
-                                              G_TYPE_STRING,
-                                              G_TYPE_POINTER);
+    gtk_tree_store_clear (store);
 
     GnomeCmdCon *current_con = main_win->fs(ACTIVE)->get_connection();
     GtkTreeIter toplevel;
@@ -219,6 +216,19 @@ static GtkTreeModel *create_and_fill_model (GtkTreePath *&current_group)
                                 -1);
         }
     }
+}
+
+
+static GtkTreeModel *create_and_fill_model (GtkTreePath *&current_group)
+{
+    GtkTreeStore *store = gtk_tree_store_new (NUM_COLUMNS,
+                                              G_TYPE_STRING,
+                                              G_TYPE_STRING,
+                                              G_TYPE_STRING,
+                                              G_TYPE_STRING,
+                                              G_TYPE_POINTER);
+    fill_tree (store, current_group);
+    
 
     return GTK_TREE_MODEL (store);
 }
@@ -287,6 +297,16 @@ static GtkWidget *create_view_and_model ()
     gtk_tree_path_free (group);
 
     return view;
+}
+
+
+void gnome_cmd_update_bookmark_dialog ()
+{
+    if (view)
+    {
+        GtkTreePath *group = NULL;
+        fill_tree (GTK_TREE_STORE (gtk_tree_view_get_model (GTK_TREE_VIEW (view))), group);
+    }
 }
 
 

--- a/src/dialogs/gnome-cmd-manage-bookmarks-dialog.cc
+++ b/src/dialogs/gnome-cmd-manage-bookmarks-dialog.cc
@@ -358,6 +358,10 @@ static void remove_clicked_callback (GtkButton *button, GtkWidget *view)
             g_free (bookmark->name);
             g_free (bookmark->path);
             g_free (bookmark);
+            
+            main_win->update_bookmarks ();
+            
+            gnome_cmd_data.save_xml ();
         }
     }
 }
@@ -550,6 +554,8 @@ void gnome_cmd_bookmark_add_current (GnomeCmdDir *dir)
         group->bookmarks = g_list_append (group->bookmarks, bookmark);
 
         main_win->update_bookmarks();
+        
+        gnome_cmd_data.save_xml ();
     }
     else
     {

--- a/src/dialogs/gnome-cmd-manage-bookmarks-dialog.h
+++ b/src/dialogs/gnome-cmd-manage-bookmarks-dialog.h
@@ -29,4 +29,6 @@ void gnome_cmd_bookmark_dialog_new (const gchar *title, GtkWindow *parent);
 void gnome_cmd_bookmark_goto (GnomeCmdBookmark *bookmark);
 void gnome_cmd_bookmark_add_current (GnomeCmdDir *dir);
 
+void gnome_cmd_update_bookmark_dialog ();
+
 #endif // __GNOME_CMD_MANAGE_BOOKMARKS_DIALOG_H__

--- a/src/gnome-cmd-con.cc
+++ b/src/gnome-cmd-con.cc
@@ -383,6 +383,33 @@ void gnome_cmd_con_set_bookmarks (GnomeCmdCon *con, GnomeCmdBookmarkGroup *bookm
 }
 
 
+void gnome_cmd_con_add_bookmark (GnomeCmdCon *con, gchar *name, gchar *path)
+{
+    GnomeCmdBookmarkGroup *group = gnome_cmd_con_get_bookmarks (con);
+    GnomeCmdBookmark *bookmark = g_new (GnomeCmdBookmark, 1);
+    bookmark->name = name;
+    bookmark->path = path;
+    bookmark->group = group;
+    group->bookmarks = g_list_append (group->bookmarks, bookmark);
+}
+
+
+void gnome_cmd_con_erase_bookmark (GnomeCmdCon *con)
+{
+    GnomeCmdBookmarkGroup *group = con->priv->bookmarks;
+    for(GList *l = group->bookmarks; l; l = l->next)
+    {
+        GnomeCmdBookmark *bookmark = (GnomeCmdBookmark *) l->data;
+        g_free (bookmark->name);
+        g_free (bookmark->path);
+        g_free (bookmark);
+    }
+    g_list_free(group->bookmarks);
+    con->priv->bookmarks = g_new0 (GnomeCmdBookmarkGroup, 1);
+    con->priv->bookmarks->con = con;
+}
+
+
 void gnome_cmd_con_updated (GnomeCmdCon *con)
 {
     g_return_if_fail (GNOME_CMD_IS_CON (con));

--- a/src/gnome-cmd-con.h
+++ b/src/gnome-cmd-con.h
@@ -334,15 +334,9 @@ GnomeCmdBookmarkGroup *gnome_cmd_con_get_bookmarks (GnomeCmdCon *con);
 
 void gnome_cmd_con_set_bookmarks (GnomeCmdCon *con, GnomeCmdBookmarkGroup *bookmarks);
 
-inline void gnome_cmd_con_add_bookmark (GnomeCmdCon *con, gchar *name, gchar *path)
-{
-    GnomeCmdBookmarkGroup *group = gnome_cmd_con_get_bookmarks (con);
-    GnomeCmdBookmark *bookmark = g_new (GnomeCmdBookmark, 1);
-    bookmark->name = name;
-    bookmark->path = path;
-    bookmark->group = group;
-    group->bookmarks = g_list_append (group->bookmarks, bookmark);
-}
+void gnome_cmd_con_add_bookmark (GnomeCmdCon *con, gchar *name, gchar *path);
+
+void gnome_cmd_con_erase_bookmark (GnomeCmdCon *con);
 
 void gnome_cmd_con_updated (GnomeCmdCon *con);
 

--- a/src/gnome-cmd-data.cc
+++ b/src/gnome-cmd-data.cc
@@ -38,6 +38,7 @@
 #include "utils.h"
 #include "owner.h"
 #include "dialogs/gnome-cmd-advrename-dialog.h"
+#include "dialogs/gnome-cmd-manage-bookmarks-dialog.h"
 #include "gnome-cmd-gkeyfile-utils.h"
 
 using namespace std;
@@ -1352,6 +1353,7 @@ static void settings_file_changes (GFileMonitor *monitor, GFile *file, GFile *ot
         {
             gnome_cmd_data.load ();
             main_win->update_bookmarks ();
+            gnome_cmd_update_bookmark_dialog ();
         }
     }
 }

--- a/src/gnome-cmd-data.h
+++ b/src/gnome-cmd-data.h
@@ -425,6 +425,7 @@ struct GnomeCmdData
     void save_auto_load_plugins();
     void save_cmdline_history();
     void save_intviewer_defaults();
+	void set_settings_monitor (const char *file_path);
 
   public:
 
@@ -474,6 +475,8 @@ struct GnomeCmdData
     void load();
     void load_more();
     void save();
+	
+	void save_xml ();
 
     GnomeCmdConRemote *get_quick_connect() const       {  return quick_connect;                     }
 

--- a/src/gnome-cmd-dir-indicator.cc
+++ b/src/gnome-cmd-dir-indicator.cc
@@ -29,6 +29,7 @@
 #include "gnome-cmd-main-win.h"
 #include "gnome-cmd-data.h"
 #include "gnome-cmd-user-actions.h"
+#include "dialogs/gnome-cmd-manage-bookmarks-dialog.h"
 #include "imageloader.h"
 #include "utils.h"
 
@@ -400,18 +401,7 @@ void gnome_cmd_dir_indicator_show_history (GnomeCmdDirIndicator *indicator)
 
 static void on_bookmarks_add_current (GtkMenuItem *item, GnomeCmdDirIndicator *indicator)
 {
-    GnomeCmdFile *f = GNOME_CMD_FILE (indicator->priv->fs->get_directory());
-    GnomeCmdCon *con = indicator->priv->fs->get_connection();
-    GnomeCmdBookmarkGroup *group = gnome_cmd_con_get_bookmarks (con);
-
-    GnomeCmdBookmark *bm = g_new0 (GnomeCmdBookmark, 1);
-
-    bm->name = g_strdup (f->get_name());
-    bm->path = f->get_path();
-    bm->group = group;
-
-    group->bookmarks = g_list_append (group->bookmarks, bm);
-    main_win->update_bookmarks();
+    gnome_cmd_bookmark_add_current (indicator->priv->fs->get_directory());
 }
 
 

--- a/src/gnome-cmd-xml-config.cc
+++ b/src/gnome-cmd-xml-config.cc
@@ -528,7 +528,9 @@ static void xml_start(GMarkupParseContext *context,
                                              G_MARKUP_COLLECT_INVALID))
             {
                 if (gnome_cmd_con_list_get()->has_alias(param1))
-                    g_warning ("<Connections> duplicate entry: '%s' - ignored", param1);
+                {
+                    gnome_cmd_con_erase_bookmark (gnome_cmd_con_list_get()->find_alias(param1));
+                }
                 else
                 {
                     GnomeCmdConRemote *server = gnome_cmd_con_remote_new (param1, param2);


### PR DESCRIPTION
How it work:

![preview]
(http://i.mcgl.ru/oMgobQhyOr)

This feature covers of similar from TODO "Write bookmark changes immediately to file".

Together with bookmarks synchronized all that is stored in the XML file.

Plese test this feature :)